### PR TITLE
Fix parsing 'space' argument

### DIFF
--- a/src/jquery.typedText.js
+++ b/src/jquery.typedText.js
@@ -67,7 +67,7 @@
                         case "number":
                              // Check if the var that holds the desired amount of time -- that should
                              // pass between each letter being displayed -- has not been set yet
-                             if(givenArgs.space !== 66) {
+                             if(givenArgs.space !== currentArg) {
                                 givenArgs.space = currentArg;
                              }
                         break;


### PR DESCRIPTION
The 'space' argument is not properly parsed and text is always being typed with default speed.
This change will fix it.
